### PR TITLE
feat: add PlaceholderTransitions presets for fade animations

### DIFF
--- a/app/src/main/kotlin/com/revenuecat/placeholderdemo/MainActivity.kt
+++ b/app/src/main/kotlin/com/revenuecat/placeholderdemo/MainActivity.kt
@@ -46,103 +46,103 @@ import com.revenuecat.placeholder.placeholder
 import kotlinx.coroutines.delay
 
 class MainActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
 
-        setContent {
-            var enabled by remember { mutableStateOf(true) }
+    setContent {
+      var enabled by remember { mutableStateOf(true) }
 
-            LaunchedEffect(Unit) {
-                delay(5000)
-                enabled = false
-            }
+      LaunchedEffect(Unit) {
+        delay(5000)
+        enabled = false
+      }
 
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = 10.dp),
-            ) {
-                Item(
-                    enabled = enabled,
-                    highlight = PlaceholderDefaults.shimmer,
-                    transitionSpec = PlaceholderTransitions.fast
-                )
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .padding(top = 10.dp),
+      ) {
+        Item(
+          enabled = enabled,
+          highlight = PlaceholderDefaults.shimmer,
+          transitionSpec = PlaceholderTransitions.fast,
+        )
 
-                Item(
-                    enabled = enabled,
-                    highlight = PlaceholderDefaults.fade,
-                    transitionSpec = PlaceholderTransitions.smooth
-                )
+        Item(
+          enabled = enabled,
+          highlight = PlaceholderDefaults.fade,
+          transitionSpec = PlaceholderTransitions.smooth,
+        )
 
-                Item(
-                    enabled = enabled,
-                    highlight = PlaceholderDefaults.pulse,
-                    transitionSpec = PlaceholderTransitions.snappy
-                )
+        Item(
+          enabled = enabled,
+          highlight = PlaceholderDefaults.pulse,
+          transitionSpec = PlaceholderTransitions.snappy,
+        )
 
-                Item(
-                    enabled = enabled,
-                    highlight = PlaceholderDefaults.lightReveal,
-                    transitionSpec = PlaceholderTransitions.bouncy
-                )
+        Item(
+          enabled = enabled,
+          highlight = PlaceholderDefaults.lightReveal,
+          transitionSpec = PlaceholderTransitions.bouncy,
+        )
 
-                Item(
-                    enabled = enabled,
-                    highlight = PlaceholderDefaults.circularReveal,
-                    transitionSpec = PlaceholderTransitions.tween(100)
-                )
-            }
-        }
+        Item(
+          enabled = enabled,
+          highlight = PlaceholderDefaults.circularReveal,
+          transitionSpec = PlaceholderTransitions.tween(100),
+        )
+      }
     }
+  }
 }
 
 @Composable
 private fun Item(
-    enabled: Boolean,
-    highlight: PlaceholderHighlight,
-    transitionSpec: () -> FiniteAnimationSpec<Float>
+  enabled: Boolean,
+  highlight: PlaceholderHighlight,
+  transitionSpec: () -> FiniteAnimationSpec<Float>,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(12.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .placeholder(
-                    enabled = enabled,
-                    highlight = highlight,
-                    contentFadeTransitionSpec = transitionSpec,
-                    placeholderFadeTransitionSpec = transitionSpec
-                )
-                .background(Color.Green)
-                .size(64.dp)
-                .clip(CircleShape),
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(12.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .placeholder(
+          enabled = enabled,
+          highlight = highlight,
+          contentFadeTransitionSpec = transitionSpec,
+          placeholderFadeTransitionSpec = transitionSpec,
         )
+        .background(Color.Green)
+        .size(64.dp)
+        .clip(CircleShape),
+    )
 
-        Column(modifier = Modifier.padding(horizontal = 10.dp)) {
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 6.dp)
-                    .placeholder(
-                        enabled = enabled,
-                        highlight = highlight,
-                        contentFadeTransitionSpec = transitionSpec,
-                        placeholderFadeTransitionSpec = transitionSpec
-                    ),
-                text = "Hello",
-            )
+    Column(modifier = Modifier.padding(horizontal = 10.dp)) {
+      Text(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(bottom = 6.dp)
+          .placeholder(
+            enabled = enabled,
+            highlight = highlight,
+            contentFadeTransitionSpec = transitionSpec,
+            placeholderFadeTransitionSpec = transitionSpec,
+          ),
+        text = "Hello",
+      )
 
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .placeholder(
-                        enabled = enabled,
-                        highlight = highlight,
-                    ),
-                text = "Hello1\nHello2\nHello3\n",
-            )
-        }
+      Text(
+        modifier = Modifier
+          .fillMaxWidth()
+          .placeholder(
+            enabled = enabled,
+            highlight = highlight,
+          ),
+        text = "Hello1\nHello2\nHello3\n",
+      )
     }
+  }
 }

--- a/app/src/main/kotlin/com/revenuecat/placeholderdemo/MainActivity.kt
+++ b/app/src/main/kotlin/com/revenuecat/placeholderdemo/MainActivity.kt
@@ -18,6 +18,7 @@ package com.revenuecat.placeholderdemo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,94 +41,108 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.revenuecat.placeholder.PlaceholderDefaults
 import com.revenuecat.placeholder.PlaceholderHighlight
+import com.revenuecat.placeholder.PlaceholderTransitions
 import com.revenuecat.placeholder.placeholder
 import kotlinx.coroutines.delay
 
 class MainActivity : ComponentActivity() {
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
 
-    setContent {
-      var enabled by remember { mutableStateOf(true) }
+        setContent {
+            var enabled by remember { mutableStateOf(true) }
 
-      LaunchedEffect(Unit) {
-        delay(5000)
-        enabled = false
-      }
+            LaunchedEffect(Unit) {
+                delay(5000)
+                enabled = false
+            }
 
-      Column(
-        modifier = Modifier
-          .fillMaxSize()
-          .padding(top = 10.dp),
-      ) {
-        Item(
-          enabled = enabled,
-          highlight = PlaceholderDefaults.shimmer,
-        )
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 10.dp),
+            ) {
+                Item(
+                    enabled = enabled,
+                    highlight = PlaceholderDefaults.shimmer,
+                    transitionSpec = PlaceholderTransitions.fast
+                )
 
-        Item(
-          enabled = enabled,
-          highlight = PlaceholderDefaults.fade,
-        )
+                Item(
+                    enabled = enabled,
+                    highlight = PlaceholderDefaults.fade,
+                    transitionSpec = PlaceholderTransitions.smooth
+                )
 
-        Item(
-          enabled = enabled,
-          highlight = PlaceholderDefaults.pulse,
-        )
+                Item(
+                    enabled = enabled,
+                    highlight = PlaceholderDefaults.pulse,
+                    transitionSpec = PlaceholderTransitions.snappy
+                )
 
-        Item(
-          enabled = enabled,
-          highlight = PlaceholderDefaults.lightReveal,
-        )
+                Item(
+                    enabled = enabled,
+                    highlight = PlaceholderDefaults.lightReveal,
+                    transitionSpec = PlaceholderTransitions.bouncy
+                )
 
-        Item(
-          enabled = enabled,
-          highlight = PlaceholderDefaults.circularReveal,
-        )
-      }
+                Item(
+                    enabled = enabled,
+                    highlight = PlaceholderDefaults.circularReveal,
+                    transitionSpec = PlaceholderTransitions.tween(100)
+                )
+            }
+        }
     }
-  }
 }
 
 @Composable
-private fun Item(enabled: Boolean, highlight: PlaceholderHighlight) {
-  Row(
-    modifier = Modifier
-      .fillMaxWidth()
-      .padding(12.dp),
-  ) {
-    Box(
-      modifier = Modifier
-        .placeholder(
-          enabled = enabled,
-          highlight = highlight,
+private fun Item(
+    enabled: Boolean,
+    highlight: PlaceholderHighlight,
+    transitionSpec: () -> FiniteAnimationSpec<Float>
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(12.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .placeholder(
+                    enabled = enabled,
+                    highlight = highlight,
+                    contentFadeTransitionSpec = transitionSpec,
+                    placeholderFadeTransitionSpec = transitionSpec
+                )
+                .background(Color.Green)
+                .size(64.dp)
+                .clip(CircleShape),
         )
-        .background(Color.Green)
-        .size(64.dp)
-        .clip(CircleShape),
-    )
 
-    Column(modifier = Modifier.padding(horizontal = 10.dp)) {
-      Text(
-        modifier = Modifier
-          .fillMaxWidth()
-          .padding(bottom = 6.dp)
-          .placeholder(
-            enabled = enabled,
-            highlight = highlight,
-          ),
-        text = "Hello",
-      )
+        Column(modifier = Modifier.padding(horizontal = 10.dp)) {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 6.dp)
+                    .placeholder(
+                        enabled = enabled,
+                        highlight = highlight,
+                        contentFadeTransitionSpec = transitionSpec,
+                        placeholderFadeTransitionSpec = transitionSpec
+                    ),
+                text = "Hello",
+            )
 
-      Text(
-        modifier = Modifier
-          .fillMaxWidth()
-          .placeholder(
-            enabled = enabled,
-            highlight = highlight,
-          ),
-        text = "Hello1\nHello2\nHello3\n",
-      )
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .placeholder(
+                        enabled = enabled,
+                        highlight = highlight,
+                    ),
+                text = "Hello1\nHello2\nHello3\n",
+            )
+        }
     }
-  }
 }

--- a/placeholder/api/android/placeholder.api
+++ b/placeholder/api/android/placeholder.api
@@ -60,6 +60,20 @@ public abstract interface class com/revenuecat/placeholder/PlaceholderHighlight 
 	public abstract fun getAnimationSpec ()Landroidx/compose/animation/core/InfiniteRepeatableSpec;
 }
 
+public final class com/revenuecat/placeholder/PlaceholderTransitions {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/revenuecat/placeholder/PlaceholderTransitions;
+	public final fun custom (FF)Lkotlin/jvm/functions/Function0;
+	public static synthetic fun custom$default (Lcom/revenuecat/placeholder/PlaceholderTransitions;FFILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
+	public final fun getBouncy ()Lkotlin/jvm/functions/Function0;
+	public final fun getFast ()Lkotlin/jvm/functions/Function0;
+	public final fun getNormal ()Lkotlin/jvm/functions/Function0;
+	public final fun getSlow ()Lkotlin/jvm/functions/Function0;
+	public final fun getSmooth ()Lkotlin/jvm/functions/Function0;
+	public final fun getSnappy ()Lkotlin/jvm/functions/Function0;
+	public final fun tween (I)Lkotlin/jvm/functions/Function0;
+}
+
 public final class com/revenuecat/placeholder/Pulse : com/revenuecat/placeholder/PlaceholderHighlight {
 	public static final field $stable I
 	public synthetic fun <init> (JLandroidx/compose/animation/core/InfiniteRepeatableSpec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/placeholder/api/desktop/placeholder.api
+++ b/placeholder/api/desktop/placeholder.api
@@ -60,6 +60,20 @@ public abstract interface class com/revenuecat/placeholder/PlaceholderHighlight 
 	public abstract fun getAnimationSpec ()Landroidx/compose/animation/core/InfiniteRepeatableSpec;
 }
 
+public final class com/revenuecat/placeholder/PlaceholderTransitions {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/revenuecat/placeholder/PlaceholderTransitions;
+	public final fun custom (FF)Lkotlin/jvm/functions/Function0;
+	public static synthetic fun custom$default (Lcom/revenuecat/placeholder/PlaceholderTransitions;FFILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
+	public final fun getBouncy ()Lkotlin/jvm/functions/Function0;
+	public final fun getFast ()Lkotlin/jvm/functions/Function0;
+	public final fun getNormal ()Lkotlin/jvm/functions/Function0;
+	public final fun getSlow ()Lkotlin/jvm/functions/Function0;
+	public final fun getSmooth ()Lkotlin/jvm/functions/Function0;
+	public final fun getSnappy ()Lkotlin/jvm/functions/Function0;
+	public final fun tween (I)Lkotlin/jvm/functions/Function0;
+}
+
 public final class com/revenuecat/placeholder/Pulse : com/revenuecat/placeholder/PlaceholderHighlight {
 	public static final field $stable I
 	public synthetic fun <init> (JLandroidx/compose/animation/core/InfiniteRepeatableSpec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/placeholder/src/commonMain/kotlin/com/revenuecat/placeholder/PlaceholderTransitions.kt
+++ b/placeholder/src/commonMain/kotlin/com/revenuecat/placeholder/PlaceholderTransitions.kt
@@ -1,0 +1,145 @@
+package com.revenuecat.placeholder
+
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+
+/**
+ * Provides preset animation specifications for placeholder fade-in/fade-out transitions.
+ *
+ * These presets control how smoothly the placeholder appears and disappears, separate from
+ * the highlight animation effects (like shimmer or fade). Use these with the
+ * [placeholderFadeTransitionSpec] and [contentFadeTransitionSpec] parameters.
+ *
+ * Example usage:
+ * ```kotlin
+ * Box(
+ *   modifier = Modifier
+ *     .size(200.dp, 50.dp)
+ *     .placeholder(
+ *       visible = isLoading,
+ *       highlight = PlaceholderDefaults.shimmer,
+ *       placeholderFadeTransitionSpec = PlaceholderTransitions.fast,
+ *       contentFadeTransitionSpec = PlaceholderTransitions.smooth
+ *     )
+ * )
+ * ```
+ *
+ * The difference between these and [PlaceholderDefaults]:
+ * - **PlaceholderDefaults** (shimmer, fade, pulse) = The animated effect shown **on** the placeholder
+ * - **PlaceholderTransitions** = How the placeholder itself appears/disappears
+ *
+ * @see PlaceholderDefaults for highlight effect presets
+ */
+public object PlaceholderTransitions {
+
+    /**
+     * Fast transition preset for quick fade in/out (200ms).
+     *
+     * Uses a tween animation, ideal for scenarios where content loads quickly
+     * and you want minimal delay.
+     *
+     * **Best for:**
+     * - Quick API responses
+     * - Cached content
+     * - Minimal loading states
+     */
+    public val fast: () -> FiniteAnimationSpec<Float> = {
+        androidx.compose.animation.core.tween(durationMillis = 200)
+    }
+
+    /**
+     * Normal transition preset with balanced spring physics.
+     *
+     * Uses default spring animation, providing natural and responsive motion.
+     * This is the library's default behavior.
+     *
+     * **Best for:**
+     * - Standard loading scenarios
+     * - General-purpose placeholders
+     * - Most use cases
+     */
+    public val normal: () -> FiniteAnimationSpec<Float> = { spring() }
+
+    /**
+     * Smooth transition preset with gentle, elegant motion.
+     *
+     * Uses low stiffness spring for gradual transitions that feel refined.
+     *
+     * **Best for:**
+     * - Premium app experiences
+     * - Image-heavy content
+     * - When aesthetics matter
+     */
+    public val smooth: () -> FiniteAnimationSpec<Float> = {
+        spring(stiffness = Spring.StiffnessLow)
+    }
+
+    /**
+     * Slow transition preset for deliberate fade in/out (800ms).
+     *
+     * Uses a tween animation, creating a pronounced loading effect.
+     *
+     * **Best for:**
+     * - Long-running operations
+     * - Educational or onboarding flows
+     * - Emphasizing loading state
+     */
+    public val slow: () -> FiniteAnimationSpec<Float> = {
+        androidx.compose.animation.core.tween(durationMillis = 800)
+    }
+
+    /**
+     * Snappy transition preset with instant, energetic motion.
+     *
+     * Uses high stiffness spring for quick, responsive feel.
+     *
+     * **Best for:**
+     * - Interactions needing instant feedback
+     * - Small UI elements
+     * - When responsiveness is critical
+     */
+    public val snappy: () -> FiniteAnimationSpec<Float> = {
+        spring(stiffness = Spring.StiffnessHigh)
+    }
+
+    /**
+     * Bouncy transition preset with playful overshoot.
+     *
+     * Uses low damping spring that bounces slightly before settling.
+     * Adds personality to transitions.
+     *
+     * **Best for:**
+     * - Playful or casual apps
+     * - Gaming or entertainment
+     * - Adding character to loading
+     */
+    public val bouncy: () -> FiniteAnimationSpec<Float> = {
+        spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMedium
+        )
+    }
+
+    /**
+     * Creates a custom spring transition with specific damping and stiffness.
+     *
+     * @param dampingRatio Controls oscillation (higher = less bounce)
+     * @param stiffness Controls speed (higher = faster)
+     */
+    public fun custom(
+        dampingRatio: Float = Spring.DampingRatioNoBouncy,
+        stiffness: Float = Spring.StiffnessMedium,
+    ): () -> FiniteAnimationSpec<Float> = {
+        spring(dampingRatio = dampingRatio, stiffness = stiffness)
+    }
+
+    /**
+     * Creates a custom tween transition with specific duration.
+     *
+     * @param durationMillis Duration of the transition in milliseconds
+     */
+    public fun tween(durationMillis: Int): () -> FiniteAnimationSpec<Float> = {
+        androidx.compose.animation.core.tween(durationMillis = durationMillis)
+    }
+}

--- a/placeholder/src/commonMain/kotlin/com/revenuecat/placeholder/PlaceholderTransitions.kt
+++ b/placeholder/src/commonMain/kotlin/com/revenuecat/placeholder/PlaceholderTransitions.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2025 RevenueCat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.revenuecat.placeholder
 
 import androidx.compose.animation.core.FiniteAnimationSpec
@@ -33,113 +48,113 @@ import androidx.compose.animation.core.spring
  */
 public object PlaceholderTransitions {
 
-    /**
-     * Fast transition preset for quick fade in/out (200ms).
-     *
-     * Uses a tween animation, ideal for scenarios where content loads quickly
-     * and you want minimal delay.
-     *
-     * **Best for:**
-     * - Quick API responses
-     * - Cached content
-     * - Minimal loading states
-     */
-    public val fast: () -> FiniteAnimationSpec<Float> = {
-        androidx.compose.animation.core.tween(durationMillis = 200)
-    }
+  /**
+   * Fast transition preset for quick fade in/out (200ms).
+   *
+   * Uses a tween animation, ideal for scenarios where content loads quickly
+   * and you want minimal delay.
+   *
+   * **Best for:**
+   * - Quick API responses
+   * - Cached content
+   * - Minimal loading states
+   */
+  public val fast: () -> FiniteAnimationSpec<Float> = {
+    androidx.compose.animation.core.tween(durationMillis = 200)
+  }
 
-    /**
-     * Normal transition preset with balanced spring physics.
-     *
-     * Uses default spring animation, providing natural and responsive motion.
-     * This is the library's default behavior.
-     *
-     * **Best for:**
-     * - Standard loading scenarios
-     * - General-purpose placeholders
-     * - Most use cases
-     */
-    public val normal: () -> FiniteAnimationSpec<Float> = { spring() }
+  /**
+   * Normal transition preset with balanced spring physics.
+   *
+   * Uses default spring animation, providing natural and responsive motion.
+   * This is the library's default behavior.
+   *
+   * **Best for:**
+   * - Standard loading scenarios
+   * - General-purpose placeholders
+   * - Most use cases
+   */
+  public val normal: () -> FiniteAnimationSpec<Float> = { spring() }
 
-    /**
-     * Smooth transition preset with gentle, elegant motion.
-     *
-     * Uses low stiffness spring for gradual transitions that feel refined.
-     *
-     * **Best for:**
-     * - Premium app experiences
-     * - Image-heavy content
-     * - When aesthetics matter
-     */
-    public val smooth: () -> FiniteAnimationSpec<Float> = {
-        spring(stiffness = Spring.StiffnessLow)
-    }
+  /**
+   * Smooth transition preset with gentle, elegant motion.
+   *
+   * Uses low stiffness spring for gradual transitions that feel refined.
+   *
+   * **Best for:**
+   * - Premium app experiences
+   * - Image-heavy content
+   * - When aesthetics matter
+   */
+  public val smooth: () -> FiniteAnimationSpec<Float> = {
+    spring(stiffness = Spring.StiffnessLow)
+  }
 
-    /**
-     * Slow transition preset for deliberate fade in/out (800ms).
-     *
-     * Uses a tween animation, creating a pronounced loading effect.
-     *
-     * **Best for:**
-     * - Long-running operations
-     * - Educational or onboarding flows
-     * - Emphasizing loading state
-     */
-    public val slow: () -> FiniteAnimationSpec<Float> = {
-        androidx.compose.animation.core.tween(durationMillis = 800)
-    }
+  /**
+   * Slow transition preset for deliberate fade in/out (800ms).
+   *
+   * Uses a tween animation, creating a pronounced loading effect.
+   *
+   * **Best for:**
+   * - Long-running operations
+   * - Educational or onboarding flows
+   * - Emphasizing loading state
+   */
+  public val slow: () -> FiniteAnimationSpec<Float> = {
+    androidx.compose.animation.core.tween(durationMillis = 800)
+  }
 
-    /**
-     * Snappy transition preset with instant, energetic motion.
-     *
-     * Uses high stiffness spring for quick, responsive feel.
-     *
-     * **Best for:**
-     * - Interactions needing instant feedback
-     * - Small UI elements
-     * - When responsiveness is critical
-     */
-    public val snappy: () -> FiniteAnimationSpec<Float> = {
-        spring(stiffness = Spring.StiffnessHigh)
-    }
+  /**
+   * Snappy transition preset with instant, energetic motion.
+   *
+   * Uses high stiffness spring for quick, responsive feel.
+   *
+   * **Best for:**
+   * - Interactions needing instant feedback
+   * - Small UI elements
+   * - When responsiveness is critical
+   */
+  public val snappy: () -> FiniteAnimationSpec<Float> = {
+    spring(stiffness = Spring.StiffnessHigh)
+  }
 
-    /**
-     * Bouncy transition preset with playful overshoot.
-     *
-     * Uses low damping spring that bounces slightly before settling.
-     * Adds personality to transitions.
-     *
-     * **Best for:**
-     * - Playful or casual apps
-     * - Gaming or entertainment
-     * - Adding character to loading
-     */
-    public val bouncy: () -> FiniteAnimationSpec<Float> = {
-        spring(
-            dampingRatio = Spring.DampingRatioLowBouncy,
-            stiffness = Spring.StiffnessMedium
-        )
-    }
+  /**
+   * Bouncy transition preset with playful overshoot.
+   *
+   * Uses low damping spring that bounces slightly before settling.
+   * Adds personality to transitions.
+   *
+   * **Best for:**
+   * - Playful or casual apps
+   * - Gaming or entertainment
+   * - Adding character to loading
+   */
+  public val bouncy: () -> FiniteAnimationSpec<Float> = {
+    spring(
+      dampingRatio = Spring.DampingRatioLowBouncy,
+      stiffness = Spring.StiffnessMedium,
+    )
+  }
 
-    /**
-     * Creates a custom spring transition with specific damping and stiffness.
-     *
-     * @param dampingRatio Controls oscillation (higher = less bounce)
-     * @param stiffness Controls speed (higher = faster)
-     */
-    public fun custom(
-        dampingRatio: Float = Spring.DampingRatioNoBouncy,
-        stiffness: Float = Spring.StiffnessMedium,
-    ): () -> FiniteAnimationSpec<Float> = {
-        spring(dampingRatio = dampingRatio, stiffness = stiffness)
-    }
+  /**
+   * Creates a custom spring transition with specific damping and stiffness.
+   *
+   * @param dampingRatio Controls oscillation (higher = less bounce)
+   * @param stiffness Controls speed (higher = faster)
+   */
+  public fun custom(
+    dampingRatio: Float = Spring.DampingRatioNoBouncy,
+    stiffness: Float = Spring.StiffnessMedium,
+  ): () -> FiniteAnimationSpec<Float> = {
+    spring(dampingRatio = dampingRatio, stiffness = stiffness)
+  }
 
-    /**
-     * Creates a custom tween transition with specific duration.
-     *
-     * @param durationMillis Duration of the transition in milliseconds
-     */
-    public fun tween(durationMillis: Int): () -> FiniteAnimationSpec<Float> = {
-        androidx.compose.animation.core.tween(durationMillis = durationMillis)
-    }
+  /**
+   * Creates a custom tween transition with specific duration.
+   *
+   * @param durationMillis Duration of the transition in milliseconds
+   */
+  public fun tween(durationMillis: Int): () -> FiniteAnimationSpec<Float> = {
+    androidx.compose.animation.core.tween(durationMillis = durationMillis)
+  }
 }


### PR DESCRIPTION
### 🎯 Goal

Introduce `PlaceholderTransitions` to simplify placeholder fade-in/fade-out animations with convenient presets.

Currently, developers must manually create animation specs for transitions:
```kotlin
placeholderFadeTransitionSpec = { spring(stiffness = Spring.StiffnessLow) }
```

This PR adds discoverable presets:
```kotlin
placeholderFadeTransitionSpec = PlaceholderTransitions.smooth
```

**Why this matters:** Makes the API more accessible for common use cases while maintaining full customization for advanced needs.

### 🛠 Implementation Details

**Changes:**
- Added `PlaceholderTransitions` object with 6 presets: `fast`, `normal`, `smooth`, `slow`, `snappy`, `bouncy`
- Added custom builders: `custom()` and `tween()` for fine-grained control
- Comprehensive KDoc documentation explaining when to use each preset

**Design decisions:**
1. Named `PlaceholderTransitions` (not `AnimationDefaults`) to clearly distinguish from `PlaceholderDefaults` (which provides highlight effects like shimmer/fade/pulse)
2. Returns `() -> FiniteAnimationSpec<Float>` to match exact parameter signature
3. Preset values based on Material Design motion guidelines
4. 100% backward compatible - purely additive, no breaking changes

**Key distinction:**
- `PlaceholderDefaults` = animated effects **on** the placeholder (shimmer, pulse, etc.)
- `PlaceholderTransitions` = how placeholder appears/disappears

### ✍️ Examples

**Basic usage:**
```kotlin
Box(
  modifier = Modifier
    .placeholder(
      visible = isLoading,
      highlight = PlaceholderDefaults.shimmer,
      placeholderFadeTransitionSpec = PlaceholderTransitions.fast
    )
)
```

**Different in/out transitions:**
```kotlin
Text(
  text = "Loading...",
  modifier = Modifier.placeholder(
    visible = isLoading,
    placeholderFadeTransitionSpec = PlaceholderTransitions.slow,   // Slow fade in
    contentFadeTransitionSpec = PlaceholderTransitions.snappy      // Quick reveal
  )
)
```

**Custom timing:**
```kotlin
Image(
  painter = painter,
  contentDescription = null,
  modifier = Modifier.placeholder(
    visible = isLoading,
    placeholderFadeTransitionSpec = PlaceholderTransitions.tween(300)
  )
)
```

**Available presets:**
- `fast` - 200ms tween for quick loading
- `normal` - Default spring for balanced motion
- `smooth` - Low stiffness spring for elegant transitions
- `slow` - 800ms tween for deliberate loading
- `snappy` - High stiffness spring for instant feel
- `bouncy` - Low damping spring for playful effect

**Demo video:** 
[Screen_recording_20251015_064300.webm](https://github.com/user-attachments/assets/fbdfa5f3-8080-4f7d-8656-9b0900d82ca2)


### ✅ Prepare for Review

```bash
./gradlew spotlessApply  # ✅ Completed
./gradlew apiDump        # ✅ Completed
```

**API changes:**
- Added new public object: `PlaceholderTransitions`
- No modifications to existing API
- Binary compatibility maintained
