### PR TITLE
security: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
-      - uses: gradle/gradle-build-action@v3.5.0
+      - uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       - name: spotless
         run: ./gradlew spotlessCheck
 
@@ -33,7 +33,7 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
-      - uses: gradle/gradle-build-action@v3.5.0
+      - uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       - name: API check
         run: ./gradlew apiCheck
 
@@ -47,7 +47,7 @@ jobs:
           distribution: zulu
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v3.5.0
+      - uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       - name: Make Gradle executable
         run: chmod +x ./gradlew
 

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate Dokka HTML docs
         run: ./gradlew dokkaGenerateHtml
       - name: Deploy to GitHub pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/dokka/htmlMultiModule


### PR DESCRIPTION
## Summary
- Pin all `uses:` references in GitHub Actions workflows to full SHA hashes
- Prevents supply chain attacks via tag mutation or typosquatting

## Context
- https://rosesecurity.dev/2026/03/20/typosquatting-trivy.html
- Generated with [`pinact`](https://github.com/suzuki-shunsuke/pinact)

## Test plan
- [ ] Verify CI passes with pinned references
- [ ] Spot-check that pinned SHAs match expected release tags